### PR TITLE
GG 패스 가입/해지 추가

### DIFF
--- a/src/main/java/com/nhnacademy/marketgg/server/controller/MemberController.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/controller/MemberController.java
@@ -1,0 +1,52 @@
+package com.nhnacademy.marketgg.server.controller;
+
+import com.nhnacademy.marketgg.server.service.MemberService;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/shop/v1/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/ggpass/{memberId}")
+    public ResponseEntity<Boolean> checkPassUpdatedAt(@PathVariable final Long memberId) {
+        Boolean check = memberService.checkPassUpdatedAt(memberId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .location(URI.create("/shop/v1/members/ggpass/" + memberId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(check);
+    }
+
+    @PostMapping("/ggpass/join/{memberId}")
+    public ResponseEntity<Void> joinPass(@PathVariable final Long memberId) {
+        memberService.joinPass(memberId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .location(URI.create("/shop/v1/members/ggpass/join/" + memberId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    @PostMapping("/ggpass/withdraw/{memberId}")
+    public ResponseEntity<Void> withdrawPass(@PathVariable final Long memberId) {
+        memberService.withdrawPass(memberId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .location(URI.create("/shop/v1/members/ggpass/withdraw/" + memberId))
+                .contentType(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+}

--- a/src/main/java/com/nhnacademy/marketgg/server/dto/request/MemberCreateRequest.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/dto/request/MemberCreateRequest.java
@@ -1,0 +1,28 @@
+package com.nhnacademy.marketgg.server.dto.request;
+
+import com.nhnacademy.marketgg.server.entity.MemberGrade;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class MemberCreateRequest {
+
+    private MemberGrade memberGrade;
+
+    private String email;
+
+    private Character gender;
+
+    private LocalDate birthDate;
+
+    private LocalDateTime ggpassUpdateAt;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private LocalDateTime deletedAt;
+}

--- a/src/main/java/com/nhnacademy/marketgg/server/entity/Member.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/entity/Member.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.marketgg.server.entity;
 
+import com.nhnacademy.marketgg.server.dto.request.MemberCreateRequest;
 import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -51,6 +52,17 @@ public class Member {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    public Member(MemberCreateRequest memberRequest) {
+        this.memberGrade = memberRequest.getMemberGrade();
+        this.email = memberRequest.getEmail();
+        Gender = memberRequest.getGender();
+        this.birthDate = memberRequest.getBirthDate();
+        this.ggpassUpdatedAt = memberRequest.getGgpassUpdateAt();
+        this.createdAt = memberRequest.getCreatedAt();
+        this.updatedAt = memberRequest.getUpdatedAt();
+        this.deletedAt = memberRequest.getDeletedAt();
+    }
 
     public void passJoin() {
         this.ggpassUpdatedAt = (LocalDateTime.now()).plusMonths(1);

--- a/src/main/java/com/nhnacademy/marketgg/server/entity/Member.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/entity/Member.java
@@ -1,5 +1,6 @@
 package com.nhnacademy.marketgg.server.entity;
 
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,12 +35,6 @@ public class Member {
     private String email;
 
     @Column
-    private String name;
-
-    @Column(name = "phone_number")
-    private String phoneNumber;
-
-    @Column
     private Character Gender;
 
     @Column(name = "birth_date")
@@ -56,5 +51,9 @@ public class Member {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    public void passJoin() {
+        this.ggpassUpdatedAt = (LocalDateTime.now()).plusMonths(1);
+    }
 
 }

--- a/src/main/java/com/nhnacademy/marketgg/server/exception/member/MemberNotFoundException.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/exception/member/MemberNotFoundException.java
@@ -2,8 +2,9 @@ package com.nhnacademy.marketgg.server.exception.member;
 
 public class MemberNotFoundException extends IllegalArgumentException {
 
-    public MemberNotFoundException(String msg) {
-        super(msg);
-    }
+    private static final String ERROR = "회원을 찾을 수 없습니다.";
 
+    public MemberNotFoundException() {
+        super(ERROR);
+    }
 }

--- a/src/main/java/com/nhnacademy/marketgg/server/service/MemberService.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/service/MemberService.java
@@ -1,0 +1,11 @@
+package com.nhnacademy.marketgg.server.service;
+
+public interface MemberService {
+
+    Boolean checkPassUpdatedAt(final Long id);
+
+    void joinPass(final Long id);
+
+    void withdrawPass(final Long id);
+
+}

--- a/src/main/java/com/nhnacademy/marketgg/server/service/impl/DefaultMemberService.java
+++ b/src/main/java/com/nhnacademy/marketgg/server/service/impl/DefaultMemberService.java
@@ -1,0 +1,42 @@
+package com.nhnacademy.marketgg.server.service.impl;
+
+import com.nhnacademy.marketgg.server.entity.Member;
+import com.nhnacademy.marketgg.server.exception.member.MemberNotFoundException;
+import com.nhnacademy.marketgg.server.repository.MemberRepository;
+import com.nhnacademy.marketgg.server.service.MemberService;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DefaultMemberService implements MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public Boolean checkPassUpdatedAt(final Long id) {
+        Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+        return member.getGgpassUpdatedAt().isBefore(LocalDateTime.now());
+    }
+
+    @Transactional
+    @Override
+    public void joinPass(final Long id) {
+            Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+            member.passJoin();
+
+            memberRepository.save(member);
+    }
+
+    @Override
+    public void withdrawPass(final Long id) {
+        Member member = memberRepository.findById(id).orElseThrow(MemberNotFoundException::new);
+
+        //TODO : GG PASS 자동결제 해지 로직 필요
+
+        memberRepository.save(member);
+    }
+
+}

--- a/src/test/java/com/nhnacademy/marketgg/server/controller/MemberControllerTest.java
+++ b/src/test/java/com/nhnacademy/marketgg/server/controller/MemberControllerTest.java
@@ -1,0 +1,68 @@
+package com.nhnacademy.marketgg.server.controller;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nhnacademy.marketgg.server.service.MemberService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    MemberService memberService;
+
+    @Test
+    @DisplayName("GG 패스 갱신일자 확인")
+    void checkPassUpdatedAt() throws Exception {
+        when(memberService.checkPassUpdatedAt(anyLong())).thenReturn(true);
+
+        this.mockMvc.perform(get("/shop/v1/members/ggpass/{memberId}", 1L))
+                .andExpect(status().isOk());
+
+        verify(memberService, times(1)).checkPassUpdatedAt(anyLong());
+    }
+
+    @Test
+    @DisplayName("GG 패스 가입")
+    void joinPass() throws Exception {
+        doNothing().when(memberService).joinPass(anyLong());
+
+        this.mockMvc.perform(post("/shop/v1/members/ggpass/join/{memberId}", 1L))
+                .andExpect(status().isOk());
+
+        verify(memberService, times(1)).joinPass(anyLong());
+    }
+
+    @Test
+    @DisplayName("GG 패스 해지")
+    void withdrawPass() throws Exception {
+        doNothing().when(memberService).withdrawPass(anyLong());
+
+        this.mockMvc.perform(post("/shop/v1/members/ggpass/withdraw/{memberId}", 1L))
+                .andExpect(status().isOk());
+
+        verify(memberService, times(1)).withdrawPass(anyLong());
+    }
+
+}

--- a/src/test/java/com/nhnacademy/marketgg/server/service/impl/DefaultCategoryServiceTest.java
+++ b/src/test/java/com/nhnacademy/marketgg/server/service/impl/DefaultCategoryServiceTest.java
@@ -1,28 +1,5 @@
 package com.nhnacademy.marketgg.server.service.impl;
 
-import com.nhnacademy.marketgg.server.dto.request.CategorizationCreateRequest;
-import com.nhnacademy.marketgg.server.dto.request.CategoryCreateRequest;
-import com.nhnacademy.marketgg.server.dto.response.CategoryRetrieveResponse;
-import com.nhnacademy.marketgg.server.dto.request.CategoryUpdateRequest;
-import com.nhnacademy.marketgg.server.entity.Categorization;
-import com.nhnacademy.marketgg.server.entity.Category;
-import com.nhnacademy.marketgg.server.exception.categorization.CategorizationNotFoundException;
-import com.nhnacademy.marketgg.server.exception.category.CategoryNotFoundException;
-import com.nhnacademy.marketgg.server.repository.CategorizationRepository;
-import com.nhnacademy.marketgg.server.repository.CategoryRepository;
-import com.nhnacademy.marketgg.server.service.CategoryService;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,17 +9,39 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
+import com.nhnacademy.marketgg.server.dto.request.CategorizationCreateRequest;
+import com.nhnacademy.marketgg.server.dto.request.CategoryCreateRequest;
+import com.nhnacademy.marketgg.server.dto.request.CategoryUpdateRequest;
+import com.nhnacademy.marketgg.server.dto.response.CategoryRetrieveResponse;
+import com.nhnacademy.marketgg.server.entity.Categorization;
+import com.nhnacademy.marketgg.server.entity.Category;
+import com.nhnacademy.marketgg.server.exception.categorization.CategorizationNotFoundException;
+import com.nhnacademy.marketgg.server.exception.category.CategoryNotFoundException;
+import com.nhnacademy.marketgg.server.repository.CategorizationRepository;
+import com.nhnacademy.marketgg.server.repository.CategoryRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
 @Transactional
 class DefaultCategoryServiceTest {
 
-    @Autowired
-    CategoryService categoryService;
+    @InjectMocks
+    DefaultCategoryService categoryService;
 
-    @MockBean
+    @Mock
     CategoryRepository categoryRepository;
 
-    @MockBean
+    @Mock
     CategorizationRepository categorizationRepository;
 
     private CategoryCreateRequest categoryCreateRequest;
@@ -106,7 +105,8 @@ class DefaultCategoryServiceTest {
     @DisplayName("카테고리 수정 성공")
     void testUpdateCategorySuccess() {
         when(categoryRepository.findById(anyString()))
-                .thenReturn(Optional.of(new Category(categoryCreateRequest, new Categorization(categorizationCreateRequest))));
+                .thenReturn(Optional.of(new Category(categoryCreateRequest, new Categorization(
+                        categorizationCreateRequest))));
         when(categorizationRepository.findById(anyString()))
                 .thenReturn(Optional.of(new Categorization(categorizationCreateRequest)));
 
@@ -129,7 +129,8 @@ class DefaultCategoryServiceTest {
     @DisplayName("카테고리 수정 실패(카테고리 분류 존재 X)")
     void testUpdateCategoryFailWhenNoCategorization() {
         when(categoryRepository.findById(anyString()))
-                .thenReturn(Optional.of(new Category(categoryCreateRequest, new Categorization(categorizationCreateRequest))));
+                .thenReturn(Optional.of(new Category(categoryCreateRequest, new Categorization(
+                        categorizationCreateRequest))));
         when(categorizationRepository.findById(anyString()))
                 .thenReturn(Optional.empty());
 
@@ -141,7 +142,8 @@ class DefaultCategoryServiceTest {
     @DisplayName("카테고리 삭제 성공")
     void testDeleteCategory() {
         when(categoryRepository.findById(anyString()))
-                .thenReturn(Optional.of(new Category(categoryCreateRequest, new Categorization(categorizationCreateRequest))));
+                .thenReturn(Optional.of(new Category(categoryCreateRequest, new Categorization(
+                        categorizationCreateRequest))));
         doNothing().when(categoryRepository).delete(any(Category.class));
 
         categoryService.deleteCategory("001001");

--- a/src/test/java/com/nhnacademy/marketgg/server/service/impl/DefaultLabelServiceTest.java
+++ b/src/test/java/com/nhnacademy/marketgg/server/service/impl/DefaultLabelServiceTest.java
@@ -1,22 +1,5 @@
 package com.nhnacademy.marketgg.server.service.impl;
 
-import com.nhnacademy.marketgg.server.dto.request.LabelCreateRequest;
-import com.nhnacademy.marketgg.server.dto.response.LabelRetrieveResponse;
-import com.nhnacademy.marketgg.server.entity.Label;
-import com.nhnacademy.marketgg.server.exception.label.LabelNotFoundException;
-import com.nhnacademy.marketgg.server.repository.LabelRepository;
-import com.nhnacademy.marketgg.server.service.LabelService;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.util.ReflectionTestUtils;
-import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -26,14 +9,30 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest
+import com.nhnacademy.marketgg.server.dto.request.LabelCreateRequest;
+import com.nhnacademy.marketgg.server.dto.response.LabelRetrieveResponse;
+import com.nhnacademy.marketgg.server.entity.Label;
+import com.nhnacademy.marketgg.server.exception.label.LabelNotFoundException;
+import com.nhnacademy.marketgg.server.repository.LabelRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
 @Transactional
 class DefaultLabelServiceTest {
 
-    @Autowired
-    LabelService labelService;
+    @InjectMocks
+    DefaultLabelService labelService;
 
-    @MockBean
+    @Mock
     LabelRepository labelRepository;
 
     @Test
@@ -51,7 +50,8 @@ class DefaultLabelServiceTest {
     @Test
     @DisplayName("라벨 조회")
     void retrieveLabels() {
-        when(labelRepository.findAllLabels()).thenReturn(List.of(new LabelRetrieveResponse(1L,"hello")));
+        when(labelRepository.findAllLabels()).thenReturn(
+                List.of(new LabelRetrieveResponse(1L, "hello")));
 
         List<LabelRetrieveResponse> response = labelService.retrieveLabels();
 
@@ -61,7 +61,8 @@ class DefaultLabelServiceTest {
     @Test
     @DisplayName("라벨 삭제 성공")
     void deleteLabelSuccess() {
-        when(labelRepository.findById(anyLong())).thenReturn(Optional.of(new Label(new LabelCreateRequest())));
+        when(labelRepository.findById(anyLong())).thenReturn(
+                Optional.of(new Label(new LabelCreateRequest())));
         doNothing().when(labelRepository).delete(any(Label.class));
 
         labelService.deleteLabel(1L);
@@ -72,7 +73,7 @@ class DefaultLabelServiceTest {
     @Test
     @DisplayName("라벨 삭제 실패")
     void deleteLabelFail() {
-        assertThatThrownBy(()->labelService.deleteLabel(1L))
+        assertThatThrownBy(() -> labelService.deleteLabel(1L))
                 .isInstanceOf(LabelNotFoundException.class);
     }
 

--- a/src/test/java/com/nhnacademy/marketgg/server/service/impl/DefaultMemberServiceTest.java
+++ b/src/test/java/com/nhnacademy/marketgg/server/service/impl/DefaultMemberServiceTest.java
@@ -1,0 +1,70 @@
+package com.nhnacademy.marketgg.server.service.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.nhnacademy.marketgg.server.dto.request.MemberCreateRequest;
+import com.nhnacademy.marketgg.server.entity.Member;
+import com.nhnacademy.marketgg.server.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+class DefaultMemberServiceTest {
+
+    @InjectMocks
+    DefaultMemberService memberService;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        MemberCreateRequest memberRequest = new MemberCreateRequest();
+        member = new Member(memberRequest);
+
+        ReflectionTestUtils.setField(member, "ggpassUpdatedAt",
+                                     LocalDateTime.of(2019, 3, 11, 7, 10));
+    }
+
+    @Test
+    @DisplayName("GG 패스 갱신일 확인")
+    void checkPassUpdatedAt() {
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+
+        Boolean date = memberService.checkPassUpdatedAt(1L);
+
+        assertThat(date).isTrue();
+    }
+
+    @Test
+    @DisplayName("GG 패스 가입")
+    void joinPass() {
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+
+        memberService.joinPass(1L);
+
+        assertThat(member.getGgpassUpdatedAt()).isAfter(LocalDateTime.now());
+    }
+
+    @Test
+    @DisplayName("GG 패스 해지")
+    void withdrawPass() {
+        when(memberRepository.findById(anyLong())).thenReturn(Optional.of(member));
+
+        memberService.withdrawPass(1L);
+    }
+}


### PR DESCRIPTION
- GG 패스 가입 시도 시 Member Entity의 ggpassUpdatedAt가 현재 시간으로부터 전/후를 판단하는 서비스 추가.
- GG 패스 가입 시 (현재일시 + 1달) 로 Member Entity의 ggpassUpdatedAt 수정
- GG 패스 해지 시 Member Entity의 ggpassUpdatedAt 수정없이 후에 추가될 자동 결제를 해지하는 로직을 추가시켜줘야 함.
- Service Test의 @SpringBootTest -> @Extendwith(MockitoExtension.class) 로 변경